### PR TITLE
在return name.length之前，先对name 进行非空判定，这样可以避免出现空指针异常现象。

### DIFF
--- a/src/main/java/com/github/hcsp/pet/Cat.java
+++ b/src/main/java/com/github/hcsp/pet/Cat.java
@@ -7,6 +7,10 @@ public class Cat {
     public int getNameLength() {
         // Fix the NullPointerException thrown in this method
         // 在本方法中，修复抛出的空指针异常（NullPointerException）
+        if (name==null){
+            return 0;
+        }
+        else
         return name.length();
     }
 }


### PR DESCRIPTION
if(name==null){
   return 0;
}
else
return name.length();
//先进行判定，非空情况下再引用name.length()，这样可以避免空指针异常的情况发生。