### PR TITLE
修复Cat类对象的name变量的空指针异常

### DIFF
--- a/src/main/java/com/github/hcsp/pet/Cat.java
+++ b/src/main/java/com/github/hcsp/pet/Cat.java
@@ -7,6 +7,10 @@ public class Cat {
     public int getNameLength() {
         // Fix the NullPointerException thrown in this method
         // 在本方法中，修复抛出的空指针异常（NullPointerException）
-        return name.length();
+        if(name != null){
+        	return name.length();
+        }else{
+        	return -1;
+        }
     }
 }


### PR DESCRIPTION
修复Cat类对象的name变量的空指针异常